### PR TITLE
bump version to 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: maat
 Type: Package
 Title: Multiple Administrations Adaptive Testing
-Version: 1.0.2.9000
+Version: 1.1.0
 Date: 2021-07-08
 Authors@R: c(
     person("Seung W.", "Choi",
@@ -30,12 +30,12 @@ Authors@R: c(
         email = "garron.gianopulos@nwea.org",
         role = "ctb"))
 Maintainer: Seung W. Choi <schoi@austin.utexas.edu>
-Description: Provides an extension of the shadow-test approach to computerized adaptive 
-    testing (CAT) implemented in the 'TestDesign' package for the assessment framework 
-    involving multiple tests administered periodically throughout the year. This framework 
-    is referred to as the Multiple Administrations Adaptive Testing (MAAT) and supports 
-    multiple item pools vertically scaled and multiple phases (stages) of CAT within each test. 
-    Between phases and tests, transitioning from one item pool (and associated constraints) 
+Description: Provides an extension of the shadow-test approach to computerized adaptive
+    testing (CAT) implemented in the 'TestDesign' package for the assessment framework
+    involving multiple tests administered periodically throughout the year. This framework
+    is referred to as the Multiple Administrations Adaptive Testing (MAAT) and supports
+    multiple item pools vertically scaled and multiple phases (stages) of CAT within each test.
+    Between phases and tests, transitioning from one item pool (and associated constraints)
     to another is allowed as deemed necessary to enhance the quality of measurement.
 URL: https://choi-phd.github.io/maat/
 BugReports: https://github.com/choi-phd/maat/issues/
@@ -43,7 +43,7 @@ License: GPL (>= 2)
 Depends: R (>= 3.5.0)
 biocViews:
 Imports: TestDesign (>= 1.2.0), readxl, Rdpack, methods, MASS, diagram
-Suggests: 
+Suggests:
     testthat (>= 3.0.0),
     rmarkdown,
     knitr,
@@ -53,7 +53,7 @@ VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: true
 RdMacros: Rdpack
-Collate: 
+Collate:
     'import.R'
     'module_class.R'
     'module_functions.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# maat 1.1.0
+
+- now allows different modules to be used for different tests.
+  - `loadModules()` now returns a 3-level list instead of a 2-level list for this.
+  - all other functions are updated to work with 3-level module lists.
+  - the example data `module_list_math` is updated to the new format.
+- `plot(output_maat)` now prints the plot for the first examinee by default.
+
 # maat 1.0.2
 
 * fixed to meet CRAN requirements

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,21 +1,29 @@
-# maat 1.0.2
-
-This is a resubmission of maat 1.0.1.
-
-- Updated tests to skip most of tests on CRAN.
+# maat 1.1.0
 
 ## Test environments
 
 * Local:
-* * Windows 10 (R 4.1.0)
-* * Ubuntu 20.04 (R 4.1.0)
+  * Windows 11
+    * 4.1.2
 * GitHub Actions:
-* * Windows Server 2019 (R-release)
-* * macOS Catalina 10.15 (R-release)
-* * Ubuntu 20.04 (R-release, R-devel, R-oldrel)
+  * macOS Catalina 10.15
+    * R-release (4.1.2)
+  * Windows Server 2019
+    * R-release (4.1.2)
+    * 3.6.3
+  * Ubuntu 18.04
+    * R-devel (r81401)
+    * R-release (4.1.2)
+    * R-oldrel-1 (4.0.5)
+    * R-oldrel-2 (3.6.3)
+    * R-oldrel-3 (3.5.3)
 
 ## R CMD check results
 
 ```
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 ```
+
+## Downstream dependencies
+
+The previous version 'maat' 1.0.2 does not have downstream dependencies.


### PR DESCRIPTION
- now allows different modules to be used for different tests.
  - `loadModules()` now returns a 3-level list instead of a 2-level list for this.
  - all other functions are updated to work with 3-level module lists.
  - the example data `module_list_math` is updated to the new format.
- `plot(output_maat)` now prints the plot for the first examinee by default.