### PR TITLE
fix where `maat()` was not working if a list was supplied to `config`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: maat
 Type: Package
 Title: Multiple Administrations Adaptive Testing
-Version: 1.1.0
-Date: 2022-05-17
+Version: 1.1.0.9000
+Date: 2022-06-24
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# maat 1.1.0.9000
+
+- fixed where `maat()` was not running when a `list` object was supplied to the `config` argument.
+- updated `vignette("maat")` with an example of using module-wise configs in `maat()`.
+
 # maat 1.1.0
 
 - now uses soft overlap control. See the vignette for details.

--- a/R/sim_functions.R
+++ b/R/sim_functions.R
@@ -263,23 +263,6 @@ maat <- function(
   if (is.null(overlap_control_policy)) {
     stop("'overlap_control_policy' is required but was not supplied. See ?maat for details.")
   }
-  if (!"exclude_policy" %in% slotNames(config)) {
-    stop("'config' does not have '@exclude_policy' slot: 'config' from createShadowTestConfig() in TestDesign >= 1.3.3 is required.")
-  }
-  if ("exclude_policy" %in% slotNames(config)) {
-    if (tolower(config@exclude_policy$method) != "soft") {
-      stop(sprintf(
-        "unrecognized 'config@exclude_policy$method': %s (must be SOFT)",
-        config@exclude_policy$method
-      ))
-    }
-    if (is.null(config@exclude_policy$M)) {
-      stop(sprintf(
-        "unrecognized 'config@exclude_policy$M': NULL (must be a numeric value)"
-      ))
-    }
-  }
-
   if (!overlap_control_policy %in% c("all", "within_test", "none")) {
     stop(sprintf("unrecognized 'overlap_control_policy': %s", overlap_control_policy))
   }
@@ -354,6 +337,7 @@ maat <- function(
   names(module_list_by_name) <- module_names
 
   # Expand config to list
+
   if (inherits(config, "config_Shadow")) {
     config_list <- vector("list", n_modules)
     for (m in 1:n_modules) {
@@ -366,7 +350,35 @@ maat <- function(
     }
     config_list <- config
   }
-  config <- NULL
+
+  # Validate config objects
+
+  for (i in seq_along(config_list)) {
+    if (!inherits(config_list[[i]], "config_Shadow")) {
+      stop(sprintf(
+        "unexpected object in 'config' index %s: '%s' (must be a 'config_Shadow' object)",
+        i, class(config_list[[i]])
+      ))
+    }
+    if (!"exclude_policy" %in% slotNames(config_list[[i]])) {
+      stop(sprintf(
+        "'config' index %s does not have '@exclude_policy' slot: 'config_Shadow' object from createShadowTestConfig() in TestDesign >= 1.3.3 is required.",
+        i
+      ))
+    }
+    if (tolower(config_list[[i]]@exclude_policy$method) != "soft") {
+      stop(sprintf(
+        "unrecognized 'config' index %s '@exclude_policy$method': %s (must be SOFT)",
+        i, config_list[[i]]@exclude_policy$method
+      ))
+    }
+    if (is.null(config_list[[i]]@exclude_policy$M)) {
+      stop(sprintf(
+        "unrecognized 'config' index %s '@exclude_policy$M': NULL (must be a numeric value)",
+        i
+      ))
+    }
+  }
 
   # Determine the module
   examinee_list <- lapply(
@@ -397,7 +409,6 @@ maat <- function(
 
     examinee_current_module <- unlist(examinee_current_module)
     unique_modules <- unique(examinee_current_module)
-
 
     # Theta Estimation ---------------
 

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -35,3 +35,10 @@ html::-webkit-scrollbar {
   overflow: -moz-scrollbars-none;
   -ms-overflow-style: none;
 }
+
+#pkgdown-sidebar {
+  background: white;
+  margin-top: 0;
+  padding-top: 100px;
+  top: 0;
+} /* make toc bar appear on the front */

--- a/vignettes/maat.Rmd
+++ b/vignettes/maat.Rmd
@@ -431,7 +431,7 @@ cut_scores <- list(
 )
 ```
 
-## Create Shared Config
+## Create config object
 
 The next step is to create a config object using `createShadowTestConfig()` in the `TestDesign` package to set various shadow test configuration options. For example, the final theta estimation method in `final_theta$method` can be set to `EAP`, `MLE` or `MLEF`.
 
@@ -441,16 +441,28 @@ The exclude policy in `exclude_policy$method` must be set to `SOFT` to use the B
 library(TestDesign)
 config <- createShadowTestConfig(
   interim_theta = list(method = "MLE"),
-  final_theta = list(method = "MLE"),
+  final_theta   = list(method = "MLE"),
   exclude_policy = list(method = "SOFT", M = 100)
 )
+```
+
+Alternatively, a list of config objects can be used to use separate configs for each module. The list must have a length of 6 as per the assessment structure outlined above.
+
+```{r, results = "hide", message = FALSE}
+config_list <- list()
+config_list[[1]] <- createShadowTestConfig(exclude_policy = list(method = "SOFT", M = 100))
+config_list[[2]] <- createShadowTestConfig(exclude_policy = list(method = "SOFT", M = 100))
+config_list[[3]] <- createShadowTestConfig(exclude_policy = list(method = "SOFT", M = 100))
+config_list[[4]] <- createShadowTestConfig(exclude_policy = list(method = "SOFT", M = 100))
+config_list[[5]] <- createShadowTestConfig(exclude_policy = list(method = "SOFT", M = 100))
+config_list[[6]] <- createShadowTestConfig(exclude_policy = list(method = "SOFT", M = 100))
 ```
 
 ## Run the Main Simulation
 
 The final step is to run the main simulation using `maat()`.
 
-* An illustration of the simulation for two of the transition policies: `CI` and `pool_difficulty_percentile`:  
+* An illustration of the simulation for two of the transition policies: `CI` and `pool_difficulty_percentile`:
 
 ```{r, results = "hide", message = FALSE}
 set.seed(1)
@@ -471,7 +483,7 @@ maat_output_difficulty <- maat(
   examinee_list          = examinee_list,
   assessment_structure   = assessment_structure,
   module_list            = module_list,
-  config                 = config,
+  config                 = config_list,
   cut_scores             = cut_scores,
   overlap_control_policy = "within_test",
   transition_policy      = "pool_difficulty_percentile",


### PR DESCRIPTION
## Description

- Fixed where `maat()` was not working if a list of `config_Shadow` objects was supplied to `config`. The cause of the bug was a S4 slot name validation being improperly triggered for list objects, which should not be triggered.
- Also improved the validation of `config` argument, to check each `config_Shadow` object if a list was supplied.
- Updated `vignette("maat")` with an example to how to use module-wise config.