### PR TITLE
fix github actions status badge

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -25,7 +25,6 @@ jobs:
           - {os: ubuntu-latest , r: 'release'}
           - {os: ubuntu-latest , r: 'oldrel-1'}
           - {os: ubuntu-latest , r: 'oldrel-2'}
-          - {os: ubuntu-latest , r: 'oldrel-3'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/r_other_branches.yml
+++ b/.github/workflows/r_other_branches.yml
@@ -23,7 +23,6 @@ jobs:
           - {os: ubuntu-latest , r: 'release'}
           - {os: ubuntu-latest , r: 'oldrel-1'}
           - {os: ubuntu-latest , r: 'oldrel-2'}
-          - {os: ubuntu-latest , r: 'oldrel-3'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/README.Rmd
+++ b/README.Rmd
@@ -7,7 +7,7 @@ output: github_document
 Multiple Administrations Adaptive Testing
 
 <!-- badges: start -->
-[![R build status](https://github.com/choi-phd/maat/workflows/build/badge.svg)](https://github.com/choi-phd/maat/actions)
+[![R build status](https://github.com/choi-phd/maat/actions/workflows/r.yml/badge.svg)](https://github.com/choi-phd/maat/actions)
 [![Number of downloads](https://cranlogs.r-pkg.org/badges/grand-total/maat?color=lightgrey)](https://cran.r-project.org/package=maat)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Multiple Administrations Adaptive Testing
 <!-- badges: start -->
 
 [![R build
-status](https://github.com/choi-phd/maat/workflows/build/badge.svg)](https://github.com/choi-phd/maat/actions)
+status](https://github.com/choi-phd/maat/actions/workflows/r.yml/badge.svg)](https://github.com/choi-phd/maat/actions)
 [![Number of
 downloads](https://cranlogs.r-pkg.org/badges/grand-total/maat?color=lightgrey)](https://cran.r-project.org/package=maat)
 <!-- badges: end -->


### PR DESCRIPTION
## Description

- Fixed github actions status badge on README.
- Removed `oldrel-3` (currently resolves to R 4.0.5) from CI because of vignette rendering issues.
